### PR TITLE
Fix: Error when login to Vault with generic_svc_account

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:$VAUL
 gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:$VAULT_SERVICE_ACCOUNT --role=roles/iam.serviceAccountKeyAdmin
 gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:$VAULT_SERVICE_ACCOUNT --role=roles/compute.viewer
 gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:$VAULT_SERVICE_ACCOUNT --role=roles/storage.admin
+gcloud projects add-iam-policy-binding $PROJECT_ID --member=serviceAccount:$VAULT_SERVICE_ACCOUNT --role=roles/viewer
 ```
 
 
@@ -103,6 +104,12 @@ Version         1.3.0-dev
 Cluster Name    vault-cluster-77df4a3f
 Cluster ID      733099f6-8464-0aae-3c59-038c34825bce
 HA Enabled      false
+```
+
+Add GCP config authentication into Vault:
+
+```
+vault write auth/gcp/config credentials=@vault-svc.json
 ```
 
 Create policies to test basic vault operations. (note, these policies are permissive, its recommended to tune/restrict them)

--- a/token_policy.hcl
+++ b/token_policy.hcl
@@ -11,3 +11,12 @@ path "auth/token/lookup-accessor" {
   capabilities = [ "read", "update" ]
 }
 
+# Allow tokens to renew themselves
+path "auth/token/renew-self" {
+    capabilities = ["update"]
+}
+
+# Allow tokens to revoke themselves
+path "auth/token/revoke-self" {
+    capabilities = ["update"]
+}


### PR DESCRIPTION
When i follow this tutorial, i got 2 error:

```
# vault write -field=token auth/gcp/login role="my-gce-role" jwt="$TOKEN"
Error writing data to auth/gcp/login: Error making API request.

URL: PUT http://localhost:8200/v1/auth/gcp/login
Code: 500. Errors:

* failed to create Compute HTTP client: failed to create oauth2 http client: failed to get default credentials: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```

and:

```
vault write -field=token auth/gcp/login     role="my-gce-role"      jwt="$TOKEN"
Error writing data to auth/gcp/login: Error making API request.

URL: PUT http://localhost:8200/v1/auth/gcp/login
Code: 400. Errors:

* error when attempting to find instance (project $PROJECT_ID, zone: asia-east1-a, instance: $INSTANCE_NAME) :unable to find instance associated with token: googleapi: Error 403: Required 'compute.instances.get' permission for 'projects/$PROJECT_ID/zones/asia-east1-a/instances/$INSTANCE_NAME', forbidden
```

- The reason is the tutorial miss the step with push vault_svc_account credentials to vault server and GCP need to grant permission "project viewer" to vault_svc_account.